### PR TITLE
Added get & set cookie options for managing cookies 

### DIFF
--- a/nodejs/GPUdb.js
+++ b/nodejs/GPUdb.js
@@ -257,6 +257,8 @@ GPUdb.prototype.submit_request = function(endpoint, request, callback) {
     var timeout = this.timeout;
     var urls = this.urls;
     var authorization = this.authorization;
+		var getCookie = this.getCookie;
+		var setCookie = this.setCookie;
 
 	/// Wraps the async callback with auto-retry logic
     var failureWrapperCB = function(err, data, url) {
@@ -289,13 +291,12 @@ GPUdb.prototype.submit_request = function(endpoint, request, callback) {
             headers["Authorization"] = authorization;
         }
 
-        if (this.getCookie && typeof this.getCookie === "function") {
-            headers["Cookie"] = this.getCookie();
+        if (getCookie && typeof getCookie === "function") {
+            headers["Cookie"] = getCookie();
         }
 
         var got_error = false;
 
-        var self = this;
         var req = http.request({
                 hostname: connToken.hostname,
                 port: connToken.port,
@@ -304,8 +305,8 @@ GPUdb.prototype.submit_request = function(endpoint, request, callback) {
                 headers: headers
             }, function(res) {
                 var responseString = "";
-                if (self.setCookie && typeof self.setCookie === "function") {
-                    self.setCookie(res.headers["set-cookie"]);
+                if (setCookie && typeof setCookie === "function") {
+                    setCookie(res.headers["set-cookie"]);
                 }
 
                 res.on("data", function(chunk) {
@@ -396,6 +397,8 @@ GPUdb.prototype.wms_request = function(request, callback) {
     var timeout = this.timeout;
     var urls = this.urls;
     var authorization = this.authorization;
+		var getCookie = this.getCookie;
+		var setCookie = this.setCookie;
 
 	/// Wraps the async callback with auto-retry logic
     var failureWrapperCB = function(err, data, url) {
@@ -428,13 +431,12 @@ GPUdb.prototype.wms_request = function(request, callback) {
             headers["Authorization"] = authorization;
         }
 
-        if (this.getCookie && typeof this.getCookie === "function") {
-            headers["Cookie"] = this.getCookie();
+        if (getCookie && typeof getCookie === "function") {
+            headers["Cookie"] = getCookie();
         }
 
         var got_error = false;
 
-        var self = this;
         var req = http.request({
             hostname: connToken.hostname,
             port: connToken.port,
@@ -442,8 +444,8 @@ GPUdb.prototype.wms_request = function(request, callback) {
             headers: headers,
         }, function(res) {
             var data = [];
-            if (self.setCookie && typeof self.setCookie === "function") {
-                self.setCookie(res.headers["set-cookie"]);
+            if (setCookie && typeof setCookie === "function") {
+                setCookie(res.headers["set-cookie"]);
             }
 
             res.on("data", function(chunk) {
@@ -899,7 +901,7 @@ GPUdb.Type.prototype.create = function(gpudb, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -934,7 +936,7 @@ GPUdb.prototype.admin_delete_node_request = function(request, callback) {
  * @param {String} authorization
  * @param {Object} options
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -968,7 +970,7 @@ GPUdb.prototype.admin_delete_node = function(rank, authorization, options, callb
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -999,7 +1001,7 @@ GPUdb.prototype.admin_get_shard_assignments_request = function(request, callback
  *
  * @param {Object} options
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -1033,7 +1035,7 @@ GPUdb.prototype.admin_get_shard_assignments = function(options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1068,7 +1070,7 @@ GPUdb.prototype.admin_offline_request = function(request, callback) {
  *                           true, false.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1100,7 +1102,7 @@ GPUdb.prototype.admin_offline = function(offline, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -1133,7 +1135,7 @@ GPUdb.prototype.admin_rebalance_request = function(request, callback) {
  * @param {String[]} table_names
  * @param {Object} options
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -1166,7 +1168,7 @@ GPUdb.prototype.admin_rebalance = function(table_names, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -1207,7 +1209,7 @@ GPUdb.prototype.admin_set_shard_assignments_request = function(request, callback
  * @param {Number[]} assignment_index
  * @param {Object} options
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -1245,7 +1247,7 @@ GPUdb.prototype.admin_set_shard_assignments = function(version, partial_reassign
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1282,7 +1284,7 @@ GPUdb.prototype.admin_shutdown_request = function(request, callback) {
  *                                string.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1318,7 +1320,7 @@ GPUdb.prototype.admin_shutdown = function(exit_type, authorization, options, cal
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1351,7 +1353,7 @@ GPUdb.prototype.admin_verify_db_request = function(request, callback) {
  *
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1384,7 +1386,7 @@ GPUdb.prototype.admin_verify_db = function(options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1428,7 +1430,7 @@ GPUdb.prototype.aggregate_convex_hull_request = function(request, callback) {
  *                                being performed.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1482,7 +1484,7 @@ GPUdb.prototype.aggregate_convex_hull = function(table_name, x_column_name, y_co
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1594,7 +1596,7 @@ GPUdb.prototype.aggregate_group_by_request = function(request, callback) {
  *                          must be the desired TTL in minutes.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1646,7 +1648,7 @@ GPUdb.prototype.aggregate_group_by = function(table_name, column_names, offset, 
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1706,7 +1708,7 @@ GPUdb.prototype.aggregate_histogram_request = function(request, callback) {
  *                          double, long, float).
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1750,7 +1752,7 @@ GPUdb.prototype.aggregate_histogram = function(table_name, column_name, start, e
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1817,7 +1819,7 @@ GPUdb.prototype.aggregate_k_means_request = function(request, callback) {
  *                          minimum. Default is 1.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1854,7 +1856,7 @@ GPUdb.prototype.aggregate_k_means = function(table_name, column_names, k, tolera
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1893,7 +1895,7 @@ GPUdb.prototype.aggregate_min_max_request = function(request, callback) {
  *                              calculated.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -1949,7 +1951,7 @@ GPUdb.prototype.aggregate_min_max = function(table_name, column_name, options, c
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2022,7 +2024,7 @@ GPUdb.prototype.aggregate_statistics_request = function(request, callback) {
  *                          average statistic.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2078,7 +2080,7 @@ GPUdb.prototype.aggregate_statistics = function(table_name, column_name, stats, 
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2170,7 +2172,7 @@ GPUdb.prototype.aggregate_statistics_by_range_request = function(request, callba
  *                          used for candlestick charting techniques.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2226,7 +2228,7 @@ GPUdb.prototype.aggregate_statistics_by_range = function(table_name, select_expr
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2319,7 +2321,7 @@ GPUdb.prototype.aggregate_unique_request = function(request, callback) {
  *                          desired TTL in minutes.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2368,7 +2370,7 @@ GPUdb.prototype.aggregate_unique = function(table_name, column_name, offset, lim
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2485,7 +2487,7 @@ GPUdb.prototype.alter_system_properties_request = function(request, callback) {
  *                                       </ul>
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2535,7 +2537,7 @@ GPUdb.prototype.alter_system_properties = function(property_updates_map, options
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2619,7 +2621,7 @@ GPUdb.prototype.alter_table_request = function(request, callback) {
  *                          change_column).
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2657,7 +2659,7 @@ GPUdb.prototype.alter_table = function(table_name, action, value, options, callb
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2702,7 +2704,7 @@ GPUdb.prototype.alter_table_metadata_request = function(request, callback) {
  *                               metadata for the table(s) will be cleared.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2736,7 +2738,7 @@ GPUdb.prototype.alter_table_metadata = function(table_names, metadata_map, optio
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2776,7 +2778,7 @@ GPUdb.prototype.alter_user_request = function(request, callback) {
  *                        <code>action</code>.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2814,7 +2816,7 @@ GPUdb.prototype.alter_user = function(name, action, value, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2855,7 +2857,7 @@ GPUdb.prototype.clear_table_request = function(request, callback) {
  *                                string.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2890,7 +2892,7 @@ GPUdb.prototype.clear_table = function(table_name, authorization, options, callb
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2925,7 +2927,7 @@ GPUdb.prototype.clear_table_monitor_request = function(request, callback) {
  *                           {@linkcode GPUdb#create_table_monitor}.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2960,7 +2962,7 @@ GPUdb.prototype.clear_table_monitor = function(topic_id, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -2995,7 +2997,7 @@ GPUdb.prototype.clear_trigger_request = function(request, callback) {
  * @param {String} trigger_id  ID for the trigger to be deactivated.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3030,7 +3032,7 @@ GPUdb.prototype.clear_trigger = function(trigger_id, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3111,7 +3113,7 @@ GPUdb.prototype.create_join_table_request = function(request, callback) {
  *                          value must be the desired TTL in minutes.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3150,7 +3152,7 @@ GPUdb.prototype.create_join_table = function(join_table_name, table_names, colum
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3214,7 +3216,7 @@ GPUdb.prototype.create_proc_request = function(request, callback) {
  *                         executed.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3252,7 +3254,7 @@ GPUdb.prototype.create_proc = function(proc_name, execution_mode, files, command
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3320,7 +3322,7 @@ GPUdb.prototype.create_projection_request = function(request, callback) {
  *                          The value must be the desired TTL in minutes.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3355,7 +3357,7 @@ GPUdb.prototype.create_projection = function(table_name, projection_name, column
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3391,7 +3393,7 @@ GPUdb.prototype.create_role_request = function(request, callback) {
  *                       existing user or role.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3433,7 +3435,7 @@ GPUdb.prototype.create_role = function(name, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3524,7 +3526,7 @@ GPUdb.prototype.create_table_request = function(request, callback) {
  *                          The value must be the desired TTL in minutes.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3567,7 +3569,7 @@ GPUdb.prototype.create_table = function(table_name, type_id, options, callback) 
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3610,7 +3612,7 @@ GPUdb.prototype.create_table_monitor_request = function(request, callback) {
  *                             a collection.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3656,7 +3658,7 @@ GPUdb.prototype.create_table_monitor = function(table_name, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3725,7 +3727,7 @@ GPUdb.prototype.create_trigger_by_area_request = function(request, callback) {
  *                             region. Must be the same length as xvals.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3774,7 +3776,7 @@ GPUdb.prototype.create_trigger_by_area = function(request_id, table_names, x_col
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3829,7 +3831,7 @@ GPUdb.prototype.create_trigger_by_range_request = function(request, callback) {
  * @param {Number} max  The upper bound (inclusive) for the trigger range.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3902,7 +3904,7 @@ GPUdb.prototype.create_trigger_by_range = function(request_id, table_names, colu
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -3984,7 +3986,7 @@ GPUdb.prototype.create_type_request = function(request, callback) {
  *                             data type).
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4022,7 +4024,7 @@ GPUdb.prototype.create_type = function(type_definition, label, properties, optio
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4087,7 +4089,7 @@ GPUdb.prototype.create_union_request = function(request, callback) {
  *                          must be the desired TTL in minutes.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4124,7 +4126,7 @@ GPUdb.prototype.create_union = function(table_name, table_names, input_column_na
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4160,7 +4162,7 @@ GPUdb.prototype.create_user_external_request = function(request, callback) {
  *                       Must not be the same name as an existing user.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4194,7 +4196,7 @@ GPUdb.prototype.create_user_external = function(name, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4234,7 +4236,7 @@ GPUdb.prototype.create_user_internal_request = function(request, callback) {
  *                           an empty string for no password.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4268,7 +4270,7 @@ GPUdb.prototype.create_user_internal = function(name, password, options, callbac
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4302,7 +4304,7 @@ GPUdb.prototype.delete_proc_request = function(request, callback) {
  *                            of a currently existing proc.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4342,7 +4344,7 @@ GPUdb.prototype.delete_proc = function(proc_name, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4404,7 +4406,7 @@ GPUdb.prototype.delete_records_request = function(request, callback) {
  *                          with the *return_record_ids* option.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4438,7 +4440,7 @@ GPUdb.prototype.delete_records = function(table_name, expressions, options, call
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4472,7 +4474,7 @@ GPUdb.prototype.delete_role_request = function(request, callback) {
  *                       role.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4505,7 +4507,7 @@ GPUdb.prototype.delete_role = function(name, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4539,7 +4541,7 @@ GPUdb.prototype.delete_user_request = function(request, callback) {
  *                       user.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4573,7 +4575,7 @@ GPUdb.prototype.delete_user = function(name, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4673,7 +4675,7 @@ GPUdb.prototype.execute_proc_request = function(request, callback) {
  *                          includes that table will be used.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4718,7 +4720,7 @@ GPUdb.prototype.execute_proc = function(proc_name, params, bin_params, input_tab
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4784,7 +4786,7 @@ GPUdb.prototype.filter_request = function(request, callback) {
  *                          be the desired TTL in minutes.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4824,7 +4826,7 @@ GPUdb.prototype.filter = function(table_name, view_name, expression, options, ca
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4884,7 +4886,7 @@ GPUdb.prototype.filter_by_area_request = function(request, callback) {
  *                             polygon representing the area to be filtered.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4927,7 +4929,7 @@ GPUdb.prototype.filter_by_area = function(table_name, view_name, x_column_name, 
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -4996,7 +4998,7 @@ GPUdb.prototype.filter_by_box_request = function(request, callback) {
  *                        greater than or equal to <code>min_y</code>.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5038,7 +5040,7 @@ GPUdb.prototype.filter_by_box = function(table_name, view_name, x_column_name, m
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5092,7 +5094,7 @@ GPUdb.prototype.filter_by_geometry_request = function(request, callback) {
  *                            intersects, overlaps, touches, within.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5141,7 +5143,7 @@ GPUdb.prototype.filter_by_geometry = function(table_name, view_name, column_name
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5203,7 +5205,7 @@ GPUdb.prototype.filter_by_list_request = function(request, callback) {
  *                          filter mode, either 'in_list' or 'not_in_list'.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5250,7 +5252,7 @@ GPUdb.prototype.filter_by_list = function(table_name, view_name, column_values_m
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5320,7 +5322,7 @@ GPUdb.prototype.filter_by_radius_request = function(request, callback) {
  *                         '42000' means 42 km.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5368,7 +5370,7 @@ GPUdb.prototype.filter_by_radius = function(table_name, view_name, x_column_name
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5425,7 +5427,7 @@ GPUdb.prototype.filter_by_range_request = function(request, callback) {
  * @param {Number} upper_bound  Value of the upper bound (inclusive).
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5475,7 +5477,7 @@ GPUdb.prototype.filter_by_range = function(table_name, view_name, column_name, l
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5556,7 +5558,7 @@ GPUdb.prototype.filter_by_series_request = function(request, callback) {
  *                          great_circle.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5596,7 +5598,7 @@ GPUdb.prototype.filter_by_series = function(table_name, view_name, track_id, tar
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5655,7 +5657,7 @@ GPUdb.prototype.filter_by_string_request = function(request, callback) {
  *                          'search' mode. Values: true, false.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5700,7 +5702,7 @@ GPUdb.prototype.filter_by_string = function(table_name, view_name, expression, m
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5789,7 +5791,7 @@ GPUdb.prototype.filter_by_table_request = function(request, callback) {
  *                          <code>spatial</code> mode.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5835,7 +5837,7 @@ GPUdb.prototype.filter_by_table = function(table_name, view_name, column_name, s
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5894,7 +5896,7 @@ GPUdb.prototype.filter_by_value_request = function(request, callback) {
  *                              would be applied.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -5941,7 +5943,7 @@ GPUdb.prototype.filter_by_value = function(table_name, view_name, is_string, val
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6020,7 +6022,7 @@ GPUdb.prototype.get_records_request = function(request, callback) {
  *                          to be provided. Values: ascending, descending.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6079,7 +6081,7 @@ GPUdb.prototype.get_records = function(table_name, offset, limit, options, callb
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6167,7 +6169,7 @@ GPUdb.prototype.get_records_by_column_request = function(request, callback) {
  *                          than the original column name.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6222,7 +6224,7 @@ GPUdb.prototype.get_records_by_column = function(table_name, column_names, offse
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6294,7 +6296,7 @@ GPUdb.prototype.get_records_by_series_request = function(request, callback) {
  *                        returned.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6346,7 +6348,7 @@ GPUdb.prototype.get_records_by_series = function(table_name, world_table_name, o
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6412,7 +6414,7 @@ GPUdb.prototype.get_records_from_collection_request = function(request, callback
  *                          false.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6455,7 +6457,7 @@ GPUdb.prototype.get_records_from_collection = function(table_name, offset, limit
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6492,7 +6494,7 @@ GPUdb.prototype.grant_permission_system_request = function(request, callback) {
  *                             system_admin, system_write, system_read.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6526,7 +6528,7 @@ GPUdb.prototype.grant_permission_system = function(name, permission, options, ca
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6571,7 +6573,7 @@ GPUdb.prototype.grant_permission_table_request = function(request, callback) {
  * @param {String} filter_expression  Reserved for future use.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6607,7 +6609,7 @@ GPUdb.prototype.grant_permission_table = function(name, permission, table_name, 
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6645,7 +6647,7 @@ GPUdb.prototype.grant_role_request = function(request, callback) {
  *                         user or role.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6679,7 +6681,7 @@ GPUdb.prototype.grant_role = function(role, member, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6712,7 +6714,7 @@ GPUdb.prototype.has_proc_request = function(request, callback) {
  * @param {String} proc_name  Name of the proc to check for existence.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6745,7 +6747,7 @@ GPUdb.prototype.has_proc = function(proc_name, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6778,7 +6780,7 @@ GPUdb.prototype.has_table_request = function(request, callback) {
  * @param {String} table_name  Name of the table to check for existence.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6811,7 +6813,7 @@ GPUdb.prototype.has_table = function(table_name, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6845,7 +6847,7 @@ GPUdb.prototype.has_type_request = function(request, callback) {
  *                          {@linkcode GPUdb#create_type} request.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6903,7 +6905,7 @@ GPUdb.prototype.has_type = function(type_id, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -6994,7 +6996,7 @@ GPUdb.prototype.insert_records_request = function(request, callback) {
  *                          primary/shard keys
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7038,7 +7040,7 @@ GPUdb.prototype.insert_records = function(table_name, data, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7252,7 +7254,7 @@ GPUdb.prototype.insert_records_random_request = function(request, callback) {
  *                          </ul>
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7294,7 +7296,7 @@ GPUdb.prototype.insert_records_random = function(table_name, count, options, cal
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7357,7 +7359,7 @@ GPUdb.prototype.insert_symbol_request = function(request, callback) {
  *                          then '00FF00' (i.e. green) is used by default.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7392,7 +7394,7 @@ GPUdb.prototype.insert_symbol = function(symbol_id, symbol_format, symbol_data, 
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7428,7 +7430,7 @@ GPUdb.prototype.kill_proc_request = function(request, callback) {
  *                         running proc instances will be killed.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7468,7 +7470,7 @@ GPUdb.prototype.kill_proc = function(run_id, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7515,7 +7517,7 @@ GPUdb.prototype.lock_table_request = function(request, callback) {
  *                            write-only, unlock.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7549,7 +7551,7 @@ GPUdb.prototype.lock_table = function(table_name, lock_type, options, callback) 
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7586,7 +7588,7 @@ GPUdb.prototype.revoke_permission_system_request = function(request, callback) {
  *                             Values: system_admin, system_write, system_read.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7620,7 +7622,7 @@ GPUdb.prototype.revoke_permission_system = function(name, permission, options, c
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7662,7 +7664,7 @@ GPUdb.prototype.revoke_permission_table_request = function(request, callback) {
  *                             or view.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7697,7 +7699,7 @@ GPUdb.prototype.revoke_permission_table = function(name, permission, table_name,
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7735,7 +7737,7 @@ GPUdb.prototype.revoke_role_request = function(request, callback) {
  *                         user or role.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7769,7 +7771,7 @@ GPUdb.prototype.revoke_role = function(role, member, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7811,7 +7813,7 @@ GPUdb.prototype.show_proc_request = function(request, callback) {
  *                          files will not be returned. Values: true, false.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7847,7 +7849,7 @@ GPUdb.prototype.show_proc = function(proc_name, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7894,7 +7896,7 @@ GPUdb.prototype.show_proc_status_request = function(request, callback) {
  *                          subsequent calls. Values: true, false.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7929,7 +7931,7 @@ GPUdb.prototype.show_proc_status = function(run_id, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -7967,7 +7969,7 @@ GPUdb.prototype.show_security_request = function(request, callback) {
  *                          will be returned.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8001,7 +8003,7 @@ GPUdb.prototype.show_security = function(names, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8038,7 +8040,7 @@ GPUdb.prototype.show_system_properties_request = function(request, callback) {
  *                          all properties will be returned.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8071,7 +8073,7 @@ GPUdb.prototype.show_system_properties = function(options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8103,7 +8105,7 @@ GPUdb.prototype.show_system_status_request = function(request, callback) {
  *
  * @param {Object} options  Optional parameters, currently unused.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8137,7 +8139,7 @@ GPUdb.prototype.show_system_status = function(options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8170,7 +8172,7 @@ GPUdb.prototype.show_system_timing_request = function(request, callback) {
  *
  * @param {Object} options  Optional parameters, currently unused.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8220,7 +8222,7 @@ GPUdb.prototype.show_system_timing = function(options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8293,7 +8295,7 @@ GPUdb.prototype.show_table_request = function(request, callback) {
  *                          result.
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8326,7 +8328,7 @@ GPUdb.prototype.show_table = function(table_name, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8361,7 +8363,7 @@ GPUdb.prototype.show_table_metadata_request = function(request, callback) {
  *                                returned.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8398,7 +8400,7 @@ GPUdb.prototype.show_table_metadata = function(table_names, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8440,7 +8442,7 @@ GPUdb.prototype.show_tables_by_type_request = function(request, callback) {
  *                        the given label.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8475,7 +8477,7 @@ GPUdb.prototype.show_tables_by_type = function(type_id, label, options, callback
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8512,7 +8514,7 @@ GPUdb.prototype.show_triggers_request = function(request, callback) {
  *                                triggers.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8549,7 +8551,7 @@ GPUdb.prototype.show_triggers = function(trigger_ids, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8590,7 +8592,7 @@ GPUdb.prototype.show_types_request = function(request, callback) {
  *                        {@linkcode GPUdb#create_type}.
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8643,7 +8645,7 @@ GPUdb.prototype.show_types = function(type_id, label, options, callback) {
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8739,7 +8741,7 @@ GPUdb.prototype.update_records_request = function(request, callback) {
  *                          {@linkcode GPUdb#get_records_from_collection}).
  *                          </ul>
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8779,7 +8781,7 @@ GPUdb.prototype.update_records = function(table_name, expressions, new_values_ma
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8823,7 +8825,7 @@ GPUdb.prototype.update_records_by_series_request = function(request, callback) {
  * @param {String[]} reserved
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -8858,7 +8860,7 @@ GPUdb.prototype.update_records_by_series = function(table_name, world_table_name
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -8939,7 +8941,7 @@ GPUdb.prototype.visualize_image_request = function(request, callback) {
  *                                </ul>
  * @param {Object} options
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -8985,7 +8987,7 @@ GPUdb.prototype.visualize_image = function(table_names, world_table_names, x_col
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -9074,7 +9076,7 @@ GPUdb.prototype.visualize_image_classbreak_request = function(request, callback)
  *                                </ul>
  * @param {Object} options
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -9124,7 +9126,7 @@ GPUdb.prototype.visualize_image_classbreak = function(table_names, world_table_n
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -9188,7 +9190,7 @@ GPUdb.prototype.visualize_image_heatmap_request = function(request, callback) {
  *                                </ul>
  * @param {Object} options
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -9232,7 +9234,7 @@ GPUdb.prototype.visualize_image_heatmap = function(table_names, x_column_name, y
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -9313,7 +9315,7 @@ GPUdb.prototype.visualize_image_labels_request = function(request, callback) {
  *                             EPSG:3857, WEB_MERCATOR.
  * @param {Object} options
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -9400,7 +9402,7 @@ GPUdb.prototype.visualize_image_labels = function(table_name, x_column_name, y_c
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -9545,7 +9547,7 @@ GPUdb.prototype.visualize_video_request = function(request, callback) {
  *                                </ul>
  * @param {Object} options  Optional parameters.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  */
@@ -9593,7 +9595,7 @@ GPUdb.prototype.visualize_video = function(table_names, world_table_names, track
  * @param {Object} request  Request object containing the parameters for the
  *                          operation.
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private
@@ -9661,7 +9663,7 @@ GPUdb.prototype.visualize_video_heatmap_request = function(request, callback) {
  *                                </ul>
  * @param {Object} options
  * @param {GPUdbCallback} callback  Callback that handles the response.
- * 
+ *
  * @returns {Promise} A promise that will be fulfilled with the response
  *                    object, if no callback function is provided.
  * @private

--- a/nodejs/GPUdb.js
+++ b/nodejs/GPUdb.js
@@ -163,6 +163,30 @@ function GPUdb(url, options) {
             enumerable: true,
             value: options.timeout !== undefined && options.timeout !== null && options.timeout >= 0 ? options.timeout : 0
         });
+
+        /**
+         * Function to get request cookie
+         *
+         * @name GPUdb#getCookie
+         * @type Function
+         * @readonly
+         */
+        Object.defineProperty(this, "getCookie", {
+            enumerable: true,
+            value: options.getCookie
+        });
+
+        /**
+         * Function to set responce cookie
+         *
+         * @name GPUdb#setCookie
+         * @type Function
+         * @readonly
+         */
+        Object.defineProperty(this, "setCookie", {
+            enumerable: true,
+            value: options.setCookie
+        });
     } else {
         Object.defineProperty(this, "username", { enumerable: true, value: "" });
         Object.defineProperty(this, "password", { enumerable: true, value: "" });
@@ -265,8 +289,13 @@ GPUdb.prototype.submit_request = function(endpoint, request, callback) {
             headers["Authorization"] = authorization;
         }
 
+        if (this.getCookie && typeof this.getCookie === "function") {
+            headers["Cookie"] = this.getCookie();
+        }
+
         var got_error = false;
 
+        var self = this;
         var req = http.request({
                 hostname: connToken.hostname,
                 port: connToken.port,
@@ -275,6 +304,9 @@ GPUdb.prototype.submit_request = function(endpoint, request, callback) {
                 headers: headers
             }, function(res) {
                 var responseString = "";
+                if (self.setCookie && typeof self.setCookie === "function") {
+                    self.setCookie(res.headers["set-cookie"]);
+                }
 
                 res.on("data", function(chunk) {
                     responseString += chunk;
@@ -396,8 +428,13 @@ GPUdb.prototype.wms_request = function(request, callback) {
             headers["Authorization"] = authorization;
         }
 
+        if (this.getCookie && typeof this.getCookie === "function") {
+            headers["Cookie"] = this.getCookie();
+        }
+
         var got_error = false;
 
+        var self = this;
         var req = http.request({
             hostname: connToken.hostname,
             port: connToken.port,
@@ -405,6 +442,9 @@ GPUdb.prototype.wms_request = function(request, callback) {
             headers: headers,
         }, function(res) {
             var data = [];
+            if (self.setCookie && typeof self.setCookie === "function") {
+                self.setCookie(res.headers["set-cookie"]);
+            }
 
             res.on("data", function(chunk) {
                 data.push(chunk);


### PR DESCRIPTION
Allows both sending cookies into Kinetica requests and retrieving Set-Cookie headers from Kinetica responses. Our use case is for enabling sticky sessions with an AWS load balancer between our node app and Kinetica.

http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#sticky-sessions